### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 # This file is used to ignore files which are generated
 # ----------------------------------------------------------------------------
 
+# manually added
+
+*.pro
+main.cpp
+
+# automatically added
+
 *~
 *.autosave
 *.a

--- a/Exceptions.h
+++ b/Exceptions.h
@@ -3,12 +3,40 @@
 
 #include <exception>
 
-class InvalidAppendAfterBuild : public std::exception
+class StringBuilder_InvalidAppendAfterBuild : public std::exception
 {
 public:
     virtual const char* what() const noexcept
     {
         return "StringBuilder: Append after build not allowed!";
+    }
+};
+
+class StringBuilder_DoubleBuildNotAllowed : public std::exception
+{
+public:
+    virtual const char* what() const noexcept
+    {
+        return "StringBuilder: Can only build once - StringBuilder has already transferred ownership!";
+    }
+};
+
+class FormatEncodingError : public std::exception
+{
+public:
+    virtual const char* what() const noexcept
+    {
+        // Helping the user guess what happened.
+        return "Format encoding failed. Possibly invalid format passed or wrong type?";
+    }
+};
+
+class FormatWriteFault : public std::exception
+{
+public:
+    virtual const char* what() const noexcept
+    {
+        return "Writing formatted string was not successful. (vsnprintf returned >=n)";
     }
 };
 

--- a/String.cpp
+++ b/String.cpp
@@ -1,52 +1,50 @@
 #include "String.h"
 
 String::String(const char* cs)
+    : m_size(std::strlen(cs)), 
+      m_chars(std::make_unique<char[]>(m_size+1))
 {
-    m_size = std::strlen(cs);
-    m_chars = new char[m_size + 1]; // + 1 for '\0'
-    std::strcpy(m_chars, cs);
+    std::strcpy(m_chars.get(), cs);
 }
 
 String::String(const String& str)
+    : m_size(str.m_size),
+      m_chars(std::make_unique<char[]> (m_size+1))
 {
-    m_size = str.m_size;
-    m_chars = new char[m_size + 1];
-    std::strcpy(m_chars, str.m_chars);
+    std::strcpy(m_chars.get(), str.m_chars.get());
 }
 
 String::~String()
 {
-    if (m_chars) delete[] m_chars;
 }
 
 String& String::operator=(const String& str)
 {
-    if (m_chars) delete[] m_chars;
     m_size = str.m_size;
-    m_chars = new char[m_size + 1];
-    std::strcpy(m_chars, str.m_chars);
+    m_chars = std::make_unique<char[]>(m_size+1);
+    std::strcpy(m_chars.get(), str.m_chars.get());
     return *this;
 }
 
 String& String::operator=(const char* cs)
 {
-    if (m_chars) delete[] m_chars;
     m_size = std::strlen(cs);
-    m_chars = new char[m_size + 1];
-    std::strcpy(m_chars, cs);
+    m_chars = std::make_unique<char[]>(m_size+1);
+    std::strcpy(m_chars.get(), cs);
     return *this;
 }
 
 String String::format(const char* fmt, ...)
 {
+    // FIXME: Rewrite this to use variadic templates.
     String s {};
     va_list args;
     va_start(args, fmt);
     unsigned size = std::vsnprintf (NULL, 0, fmt, args);
     va_end (args);
-    s.m_chars = new char[size + 1];
+    s.m_chars = std::make_unique<char[]>(size+1);
     va_start(args, fmt);
-    std::vsnprintf (s.m_chars, size + 1, fmt, args);
+    std::vsnprintf (s.m_chars.get(), size + 1, fmt, args);
     va_end (args);
     s.m_size = size;
     return s;

--- a/String.cpp
+++ b/String.cpp
@@ -1,4 +1,5 @@
 #include "String.h"
+#include "Exceptions.h"
 
 String::String(const char* cs)
     : m_size(std::strlen(cs)), 
@@ -36,15 +37,34 @@ String& String::operator=(const char* cs)
 
 String String::format(const char* fmt, ...)
 {
+    /* NOTE:
+     * This sucks. It should not use varargs.
+     * Format Strings are a bad idea.
+     * I know this, and I am working on a better way to do this.
+     * See FIXME below.
+     */
+    
     // FIXME: Rewrite this to use variadic templates.
     String s {};
     va_list args;
     va_start(args, fmt);
-    unsigned size = std::vsnprintf (NULL, 0, fmt, args);
+    int size = std::vsnprintf (NULL, 0, fmt, args);
+    
+    // vsnprintf returns <0 if encoding error occured.
+    if (size < 0) throw FormatEncodingError();
+    
     va_end (args);
     s.m_chars = std::make_unique<char[]>(size+1);
     va_start(args, fmt);
-    std::vsnprintf (s.m_chars.get(), size + 1, fmt, args);
+    int rc = std::vsnprintf (s.m_chars.get(), size + 1, fmt, args);
+    
+    // vsnprintf returns <0 if encoding error occured.
+    if (rc < 0) throw FormatEncodingError();
+    
+    // vsnprintf returns >0 and <n on success. 
+    // This is sadly a super generic error.
+    if (rc >= size+1) throw FormatWriteFault(); 
+    
     va_end (args);
     s.m_size = size;
     return s;

--- a/String.h
+++ b/String.h
@@ -23,13 +23,13 @@ public:
     std::size_t size() const { return m_size; }
     bool empty() const { return m_size == 0; }
     
-    const char* c_str() const { return m_chars.get(); } // FIXME: Do we need this?
-    
+    /// Construct a String instance from a format string.
     static String format(const char* fmt, ...);
     
+    const char* c_str() const { return m_chars.get(); }
     friend std::ostream& operator<<(std::ostream& os, const String& str)
     {
-        return os << str.m_chars.get(); // FIXME: This is a bit hacky.
+        return os << str.m_chars.get();
     }
 private:
     std::size_t m_size;

--- a/String.h
+++ b/String.h
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <iostream>
 #include <cstdarg>
+#include <memory>
 
 #include "Core.h"
 
@@ -22,17 +23,17 @@ public:
     std::size_t size() const { return m_size; }
     bool empty() const { return m_size == 0; }
     
-    const char* c_str() const { return m_chars; }
+    const char* c_str() const { return m_chars.get(); } // FIXME: Do we need this?
     
     static String format(const char* fmt, ...);
     
     friend std::ostream& operator<<(std::ostream& os, const String& str)
     {
-        return os << str.m_chars;
+        return os << str.m_chars.get(); // FIXME: This is a bit hacky.
     }
 private:
-    char* m_chars;
     std::size_t m_size;
+    std::unique_ptr<char[]> m_chars;
     String () {}
 };
 

--- a/StringBuilder.h
+++ b/StringBuilder.h
@@ -3,6 +3,7 @@
 
 #include <cstring>
 #include <cstdarg>
+#include <memory>
 
 #include "Core.h"
 #include "String.h"
@@ -43,18 +44,12 @@ public:
     
     StringBuilder& operator=(const StringBuilder&);
     
-    /*
-    StringBuilder& operator+=(const char*);
-    StringBuilder& operator+=(const String&);
-    StringBuilder& operator+=(const class StringConverter&);
-    */
-    
     /// Returns the current contents of the char* data.
-    const char* c_str() const { return m_chars; }
+    const char* c_str() const { return m_chars.get(); }
 private:
-    char* m_chars;
-    bool m_built { false };
     std::size_t m_size;
+    std::unique_ptr<char[]> m_chars;
+    bool m_built { false };
 };
 
 #endif // STRINGBUILDER_H


### PR DESCRIPTION
Vital patches regarding exception safety.

All pointers used in both `String` and `StringBuilder` are now std::unique_ptrs and the temporary format string solutions of both `String::format` and `StringBuilder::appendf`/`StringBuilder::prependf` of using `vsnprintf` are now a bit safer until a better way to handle this (e.g. variadic templates) is implemented. 
`vsnprintf` no longer fails silently, instead throws `std::exception` derived exceptions (see `Exceptions.h`). These are very primitive and won't be around for long.

It's generally discouraged to use `String::format` and `StringBuilder::appendf`/`StringBuilder::prependf` until a "non-printf" way is implemented.