### PR TITLE
Make String 32-bit aware

### DIFF
--- a/String.h
+++ b/String.h
@@ -11,7 +11,7 @@
 #include "StringBuilder.h"
 #include "StringView.h"
 
-static constexpr unsigned char MAX_ALLOC = 3*std::numeric_limits<std::size_t>::digits - 1;
+static constexpr unsigned char MAX_ALLOC = 3*sizeof(void*) - 1;
 
 static constexpr char to_lower_internal(const char c) {
     return (c >= 'A' && c <= 'Z') ? c + ('a' - 'A') : c;

--- a/String.h
+++ b/String.h
@@ -11,7 +11,7 @@
 #include "StringBuilder.h"
 #include "StringView.h"
 
-static constexpr unsigned char MAX_ALLOC = 23;
+static constexpr unsigned char MAX_ALLOC = 3*std::numeric_limits<std::size_t>::digits - 1;
 
 static constexpr char to_lower_internal(const char c) {
     return (c >= 'A' && c <= 'Z') ? c + ('a' - 'A') : c;


### PR DESCRIPTION
This PR changes `MAX_ALLOC` to `3*std::numeric_limits<std::size_t>::digits - 1`, so that it does not waste space in a 32-bit implementation. Previously, the string would waste 12 bytes at the end of the string in 32-bit architectures because the dynamic structure would have only 12 bytes, but the static one would have 24 bytes. With this proposal, the String has 12 bytes on 32-bit implementations and 24 bytes on 64-bit implementations.